### PR TITLE
feat: image reorder, cache fix, and cancel buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A production-ready **admin dashboard** for the [NestJS Ecommerce API](https://gi
 | **UI Components**   | shadcn/ui + Radix UI                              |
 | **Styling**         | Tailwind CSS 4                                    |
 | **Forms**           | React Hook Form 7 + Zod 4                         |
+| **Drag & Drop**     | @dnd-kit/react                                    |
 | **Charts**          | Recharts 3                                        |
 | **Toasts**          | Sonner                                            |
 | **API Client**      | @hey-api/openapi-ts (auto-generated from Swagger) |
@@ -47,6 +48,7 @@ A production-ready **admin dashboard** for the [NestJS Ecommerce API](https://gi
 - Category and search filters
 - Slug auto-generation from product name
 - Multi-image upload with drag-and-drop (Cloudinary via backend)
+- Drag-to-reorder images with "Main" badge (first image = primary)
 - Featured and active toggles
 
 ### Category Management
@@ -122,6 +124,7 @@ A production-ready **admin dashboard** for the [NestJS Ecommerce API](https://gi
 - Loading skeletons, empty states, confirmation dialogs
 - Global error boundary + route-level error components
 - Offline detection banner
+- Cancel buttons on all create/edit forms
 - Toast notifications on all mutations
 
 ---

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "size:check": "size-limit --json"
   },
   "dependencies": {
+    "@dnd-kit/helpers": "^0.3.2",
+    "@dnd-kit/react": "^0.3.2",
     "@hookform/resolvers": "^5.2.2",
     "@tanstack/react-query": "^5.96.2",
     "@tanstack/react-router": "^1.168.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/helpers':
+        specifier: ^0.3.2
+        version: 0.3.2
+      '@dnd-kit/react':
+        specifier: ^0.3.2
+        version: 0.3.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.72.1(react@19.2.4))
@@ -384,6 +390,30 @@ packages:
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
+
+  '@dnd-kit/abstract@0.3.2':
+    resolution: {integrity: sha512-uvPVK+SZYD6Viddn9M0K0JQdXknuVSxA/EbMlFRanve3P/XTc18oLa5zGftKSGjfQGmuzkZ34E26DSbly1zi3Q==}
+
+  '@dnd-kit/collision@0.3.2':
+    resolution: {integrity: sha512-pNmNSLCI8S9fNQ7QJ3fBCDjiT0sqBhUFcKgmyYaGvGCAU+kq0AP8OWlh0JSisc9k5mFyxmRpmFQcnJpILz/RPA==}
+
+  '@dnd-kit/dom@0.3.2':
+    resolution: {integrity: sha512-cIUAVgt2szQyz6JRy7I+0r+xeyOAGH21Y15hb5bIyHoDEaZBvIDH+OOlD9eoLjCbsxDLN9WloU2CBi3OE6LYDg==}
+
+  '@dnd-kit/geometry@0.3.2':
+    resolution: {integrity: sha512-3UBPuIS7E3oGiHxOE8h810QA+0pnrnCtGxl4Os1z3yy5YkC/BEYGY+TxWPTQaY1/OMV7GCX7ZNMlama2QN3n3w==}
+
+  '@dnd-kit/helpers@0.3.2':
+    resolution: {integrity: sha512-pj7pCE6BiysNetpPnzb3BJOrcKiqueUr1LFg6wYoi2fIFYpz66n2Ojd7HTwfwkpv0oyC3QlvA6Dk8cOmi6VavA==}
+
+  '@dnd-kit/react@0.3.2':
+    resolution: {integrity: sha512-1Opg1xw6I75Z95c+rF2NJa0pdGb8rLAENtuopKtJ1J0PudWlz+P6yL137xy/6DV43uaRmNGtsdbMbR0yRYJ72g==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@dnd-kit/state@0.3.2':
+    resolution: {integrity: sha512-dLUIkoYrIJhGXfF2wGLTfb46vUokEsO/OoE21TSfmahYrx7ysTmnwbePsznFaHlwgZhQEh6AlLvthLCeY21b1A==}
 
   '@dotenvx/dotenvx@1.59.1':
     resolution: {integrity: sha512-Qg+meC+XFxliuVSDlEPkKnaUjdaJKK6FNx/Wwl2UxhQR8pyPIuLhMavsF7ePdB9qFZUWV1jEK3ckbJir/WmF4w==}
@@ -792,6 +822,9 @@ packages:
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@preact/signals-core@1.14.1':
+    resolution: {integrity: sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -4674,6 +4707,50 @@ snapshots:
 
   '@date-fns/tz@1.4.1': {}
 
+  '@dnd-kit/abstract@0.3.2':
+    dependencies:
+      '@dnd-kit/geometry': 0.3.2
+      '@dnd-kit/state': 0.3.2
+      tslib: 2.8.1
+
+  '@dnd-kit/collision@0.3.2':
+    dependencies:
+      '@dnd-kit/abstract': 0.3.2
+      '@dnd-kit/geometry': 0.3.2
+      tslib: 2.8.1
+
+  '@dnd-kit/dom@0.3.2':
+    dependencies:
+      '@dnd-kit/abstract': 0.3.2
+      '@dnd-kit/collision': 0.3.2
+      '@dnd-kit/geometry': 0.3.2
+      '@dnd-kit/state': 0.3.2
+      tslib: 2.8.1
+
+  '@dnd-kit/geometry@0.3.2':
+    dependencies:
+      '@dnd-kit/state': 0.3.2
+      tslib: 2.8.1
+
+  '@dnd-kit/helpers@0.3.2':
+    dependencies:
+      '@dnd-kit/abstract': 0.3.2
+      tslib: 2.8.1
+
+  '@dnd-kit/react@0.3.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/abstract': 0.3.2
+      '@dnd-kit/dom': 0.3.2
+      '@dnd-kit/state': 0.3.2
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/state@0.3.2':
+    dependencies:
+      '@preact/signals-core': 1.14.1
+      tslib: 2.8.1
+
   '@dotenvx/dotenvx@1.59.1':
     dependencies:
       commander: 11.1.0
@@ -5043,6 +5120,8 @@ snapshots:
   '@playwright/test@1.59.1':
     dependencies:
       playwright: 1.59.1
+
+  '@preact/signals-core@1.14.1': {}
 
   '@radix-ui/number@1.1.1': {}
 

--- a/src/api/openapi.json
+++ b/src/api/openapi.json
@@ -7138,6 +7138,84 @@
         "tags": ["Products"]
       }
     },
+    "/api/v1/products/{id}/images/reorder": {
+      "patch": {
+        "operationId": "ProductsController_reorderImages",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Product CUID",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ReorderImagesDto" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Images reordered",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean", "example": true },
+                    "data": { "$ref": "#/components/schemas/ProductDetailDto" },
+                    "timestamp": {
+                      "type": "string",
+                      "example": "2025-01-15T12:00:00.000Z"
+                    }
+                  },
+                  "required": ["success", "data", "timestamp"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request / Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseSchema" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized — Missing or invalid JWT",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseSchema" }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — Insufficient role",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseSchema" }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponseSchema" }
+              }
+            }
+          }
+        },
+        "security": [{ "access-token": [] }],
+        "summary": "Reorder product images (admin)",
+        "tags": ["Products"]
+      }
+    },
     "/api/v1/products/{id}/images/{imageId}": {
       "delete": {
         "operationId": "ProductsController_removeImage",
@@ -10520,6 +10598,21 @@
           "isActive": { "type": "boolean" },
           "isFeatured": { "type": "boolean" }
         }
+      },
+      "ReorderImagesDto": {
+        "type": "object",
+        "properties": {
+          "imageIds": {
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "cuid",
+              "pattern": "^[cC][^\\s-]{8,}$"
+            }
+          }
+        },
+        "required": ["imageIds"]
       },
       "CartItemProductDto": {
         "type": "object",

--- a/src/features/categories/components/category-form.tsx
+++ b/src/features/categories/components/category-form.tsx
@@ -299,19 +299,29 @@ export const CategoryForm = ({ category }: CategoryFormProps) => {
             />
           </FormField>
 
-          <Button
-            type='submit'
-            disabled={
-              (!isDirty && !imageFiles.some((f) => f instanceof File)) ||
-              isPending
-            }
-          >
-            {isPending
-              ? 'Saving...'
-              : isEditing
-                ? 'Save changes'
-                : 'Create category'}
-          </Button>
+          <div className='flex justify-between'>
+            <Button
+              type='submit'
+              disabled={
+                (!isDirty && !imageFiles.some((f) => f instanceof File)) ||
+                isPending
+              }
+            >
+              {isPending
+                ? 'Saving...'
+                : isEditing
+                  ? 'Save changes'
+                  : 'Create category'}
+            </Button>
+            <Button
+              type='button'
+              variant='outline'
+              disabled={isPending}
+              onClick={() => navigate({ to: '/categories' })}
+            >
+              Cancel
+            </Button>
+          </div>
         </form>
       </CardContent>
     </Card>

--- a/src/features/coupons/components/coupon-form.tsx
+++ b/src/features/coupons/components/coupon-form.tsx
@@ -402,13 +402,23 @@ export const CouponForm = ({ coupon }: CouponFormProps) => {
             />
           </FormField>
 
-          <Button type='submit' disabled={!isDirty || isPending}>
-            {isPending
-              ? 'Saving...'
-              : isEditing
-                ? 'Save changes'
-                : 'Create coupon'}
-          </Button>
+          <div className='flex justify-between'>
+            <Button type='submit' disabled={!isDirty || isPending}>
+              {isPending
+                ? 'Saving...'
+                : isEditing
+                  ? 'Save changes'
+                  : 'Create coupon'}
+            </Button>
+            <Button
+              type='button'
+              variant='outline'
+              disabled={isPending}
+              onClick={() => navigate({ to: '/coupons' })}
+            >
+              Cancel
+            </Button>
+          </div>
         </form>
       </CardContent>
     </Card>

--- a/src/features/inventory/components/adjust-stock-form.tsx
+++ b/src/features/inventory/components/adjust-stock-form.tsx
@@ -1,6 +1,7 @@
 import { useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
 import { toast } from 'sonner';
 import { z } from 'zod/v4';
 
@@ -45,6 +46,7 @@ type AdjustStockFormProps = {
 
 export const AdjustStockForm = ({ productId }: AdjustStockFormProps) => {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   const {
     register,
@@ -167,9 +169,19 @@ export const AdjustStockForm = ({ productId }: AdjustStockFormProps) => {
             <Textarea id='reason' rows={3} {...register('reason')} />
           </FormField>
 
-          <Button type='submit' disabled={adjustMutation.isPending}>
-            {adjustMutation.isPending ? 'Adjusting...' : 'Adjust Stock'}
-          </Button>
+          <div className='flex justify-between'>
+            <Button type='submit' disabled={adjustMutation.isPending}>
+              {adjustMutation.isPending ? 'Adjusting...' : 'Adjust Stock'}
+            </Button>
+            <Button
+              type='button'
+              variant='outline'
+              disabled={adjustMutation.isPending}
+              onClick={() => navigate({ to: '/inventory' })}
+            >
+              Cancel
+            </Button>
+          </div>
         </form>
       </CardContent>
     </Card>

--- a/src/features/inventory/components/adjust-stock-form.tsx
+++ b/src/features/inventory/components/adjust-stock-form.tsx
@@ -6,9 +6,12 @@ import { z } from 'zod/v4';
 
 import {
   inventoryControllerAdjustStockMutation,
-  inventoryControllerGetStockQueryKey,
-  inventoryControllerGetMovementHistoryQueryKey,
   inventoryControllerGetLowStockProductsQueryKey,
+  inventoryControllerGetMovementHistoryQueryKey,
+  inventoryControllerGetProductsQueryKey,
+  inventoryControllerGetStockQueryKey,
+  productsControllerFindAllAdminQueryKey,
+  productsControllerFindAllQueryKey,
 } from '@/api/generated/@tanstack/react-query.gen';
 import { FormField } from '@/components/shared/form-field';
 import { Button } from '@/components/ui/button';
@@ -76,6 +79,15 @@ export const AdjustStockForm = ({ productId }: AdjustStockFormProps) => {
       });
       queryClient.invalidateQueries({
         queryKey: inventoryControllerGetLowStockProductsQueryKey(),
+      });
+      queryClient.invalidateQueries({
+        queryKey: inventoryControllerGetProductsQueryKey(),
+      });
+      queryClient.invalidateQueries({
+        queryKey: productsControllerFindAllQueryKey(),
+      });
+      queryClient.invalidateQueries({
+        queryKey: productsControllerFindAllAdminQueryKey(),
       });
       reset();
       toast.success('Stock adjusted');

--- a/src/features/products/components/product-form.tsx
+++ b/src/features/products/components/product-form.tsx
@@ -3,8 +3,6 @@ import { useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { Trash2 } from 'lucide-react';
-
 import {
   categoriesControllerFindAllAdminOptions,
   productsControllerCreateMutation,
@@ -14,10 +12,12 @@ import {
   productsControllerUpdateMutation,
   productsControllerUploadImageMutation,
   productsControllerRemoveImageMutation,
+  productsControllerReorderImagesMutation,
 } from '@/api/generated/@tanstack/react-query.gen';
 import type { ProductDetailDto } from '@/api/generated/types.gen';
 import { FormField } from '@/components/shared/form-field';
 import { ImageUpload } from '@/components/shared/image-upload';
+import { SortableImageGrid } from './sortable-image-grid';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -149,6 +149,29 @@ export const ProductForm = ({ product }: ProductFormProps) => {
       toast.success('Image removed');
     },
   });
+
+  const reorderImagesMutation = useMutation({
+    ...productsControllerReorderImagesMutation(),
+    onSuccess: () => {
+      invalidateProducts();
+      if (product) {
+        queryClient.invalidateQueries({
+          queryKey: productsControllerFindBySlugQueryKey({
+            path: { slug: product.slug },
+          }),
+        });
+      }
+      toast.success('Image order updated');
+    },
+  });
+
+  const handleReorder = (imageIds: string[]) => {
+    if (!product) return;
+    reorderImagesMutation.mutate({
+      path: { id: product.id },
+      body: { imageIds },
+    });
+  };
 
   const isPending =
     createMutation.isPending ||
@@ -365,48 +388,39 @@ export const ProductForm = ({ product }: ProductFormProps) => {
             </FormField>
           </div>
 
-          {product && product.images.length > 0 && (
-            <FormField label='Current Images' name='currentImages'>
-              <div className='flex flex-wrap gap-4'>
-                {product.images.map((image) => (
-                  <div key={image.id} className='relative'>
-                    <img
-                      src={image.url}
-                      alt={
-                        typeof image.alt === 'string' ? image.alt : product.name
-                      }
-                      className='h-20 w-20 rounded-md border object-cover sm:h-24 sm:w-24'
-                    />
-                    <Button
-                      type='button'
-                      variant='destructive'
-                      size='icon'
-                      className='absolute -top-2 -right-2 size-6'
-                      disabled={removeImageMutation.isPending}
-                      onClick={() =>
-                        removeImageMutation.mutate({
-                          path: { id: product.id, imageId: image.id },
-                        })
-                      }
-                    >
-                      <Trash2 className='size-3' />
-                    </Button>
-                  </div>
-                ))}
-              </div>
+          {isEditing && product ? (
+            <FormField label='Images' name='images'>
+              <SortableImageGrid
+                existingImages={product.images}
+                newFiles={newImageFiles}
+                onReorder={handleReorder}
+                onNewFilesReorder={setNewImageFiles}
+                onRemoveExisting={(imageId) =>
+                  removeImageMutation.mutate({
+                    path: { id: product.id, imageId },
+                  })
+                }
+                onRemoveNew={(index) =>
+                  setNewImageFiles((prev) => prev.filter((_, i) => i !== index))
+                }
+                onAddFiles={(files) =>
+                  setNewImageFiles((prev) => [...prev, ...files])
+                }
+                disabled={isPending}
+              />
+            </FormField>
+          ) : (
+            <FormField label='Add Images' name='newImage'>
+              <ImageUpload
+                value={newImageFiles}
+                onChange={(files) =>
+                  setNewImageFiles(
+                    files.filter((f): f is File => f instanceof File),
+                  )
+                }
+              />
             </FormField>
           )}
-
-          <FormField label='Add Images' name='newImage'>
-            <ImageUpload
-              value={newImageFiles}
-              onChange={(files) =>
-                setNewImageFiles(
-                  files.filter((f): f is File => f instanceof File),
-                )
-              }
-            />
-          </FormField>
 
           <Button
             type='submit'

--- a/src/features/products/components/product-form.tsx
+++ b/src/features/products/components/product-form.tsx
@@ -171,7 +171,7 @@ export const ProductForm = ({ product }: ProductFormProps) => {
   });
 
   const handleReorder = (imageIds: string[]) => {
-    setPendingImageOrder(imageIds);
+    setPendingImageOrder(imageIds.length > 0 ? imageIds : null);
   };
 
   const isPending =
@@ -420,6 +420,11 @@ export const ProductForm = ({ product }: ProductFormProps) => {
                     path: { id: product.id, imageId },
                   });
                 }
+                setPendingImageOrder((prev) => {
+                  if (!prev) return null;
+                  const filtered = prev.filter((id) => id !== imageId);
+                  return filtered.length > 0 ? filtered : null;
+                });
               }}
               onRemoveNew={(index) =>
                 setNewImageFiles((prev) => prev.filter((_, i) => i !== index))

--- a/src/features/products/components/product-form.tsx
+++ b/src/features/products/components/product-form.tsx
@@ -14,7 +14,10 @@ import {
   productsControllerRemoveImageMutation,
   productsControllerReorderImagesMutation,
 } from '@/api/generated/@tanstack/react-query.gen';
-import type { ProductDetailDto } from '@/api/generated/types.gen';
+import type {
+  ProductDetailDto,
+  ProductImageDto,
+} from '@/api/generated/types.gen';
 import { FormField } from '@/components/shared/form-field';
 import { ImageUpload } from '@/components/shared/image-upload';
 import { SortableImageGrid } from './sortable-image-grid';
@@ -110,6 +113,9 @@ export const ProductForm = ({ product }: ProductFormProps) => {
   }, [nameValue, slugManuallyEdited, setValue]);
 
   const [newImageFiles, setNewImageFiles] = useState<File[]>([]);
+  const [pendingImageOrder, setPendingImageOrder] = useState<string[] | null>(
+    null,
+  );
 
   const invalidateProducts = () => {
     queryClient.invalidateQueries({
@@ -166,17 +172,14 @@ export const ProductForm = ({ product }: ProductFormProps) => {
   });
 
   const handleReorder = (imageIds: string[]) => {
-    if (!product) return;
-    reorderImagesMutation.mutate({
-      path: { id: product.id },
-      body: { imageIds },
-    });
+    setPendingImageOrder(imageIds);
   };
 
   const isPending =
     createMutation.isPending ||
     updateMutation.isPending ||
-    uploadImageMutation.isPending;
+    uploadImageMutation.isPending ||
+    reorderImagesMutation.isPending;
 
   const onSubmit = async (values: ProductFormValues) => {
     const slugChanged = values.slug !== (product?.slug ?? '');
@@ -193,6 +196,13 @@ export const ProductForm = ({ product }: ProductFormProps) => {
           sku: values.sku || null,
         },
       });
+
+      if (pendingImageOrder) {
+        await reorderImagesMutation.mutateAsync({
+          path: { id: product.id },
+          body: { imageIds: pendingImageOrder },
+        });
+      }
 
       for (const file of newImageFiles) {
         await uploadImageMutation.mutateAsync({
@@ -217,6 +227,7 @@ export const ProductForm = ({ product }: ProductFormProps) => {
         isFeatured: updated.isFeatured,
       });
       setNewImageFiles([]);
+      setPendingImageOrder(null);
       setSlugManuallyEdited(false);
 
       if (updated.slug !== product.slug) {
@@ -391,7 +402,15 @@ export const ProductForm = ({ product }: ProductFormProps) => {
           {isEditing && product ? (
             <FormField label='Images' name='images'>
               <SortableImageGrid
-                existingImages={product.images}
+                existingImages={
+                  pendingImageOrder
+                    ? pendingImageOrder.reduce<ProductImageDto[]>((acc, id) => {
+                        const img = product.images.find((img) => img.id === id);
+                        if (img) acc.push(img);
+                        return acc;
+                      }, [])
+                    : product.images
+                }
                 newFiles={newImageFiles}
                 onReorder={handleReorder}
                 onNewFilesReorder={setNewImageFiles}
@@ -424,7 +443,12 @@ export const ProductForm = ({ product }: ProductFormProps) => {
 
           <Button
             type='submit'
-            disabled={(!isDirty && newImageFiles.length === 0) || isPending}
+            disabled={
+              (!isDirty &&
+                newImageFiles.length === 0 &&
+                pendingImageOrder === null) ||
+              isPending
+            }
           >
             {isPending
               ? 'Saving...'

--- a/src/features/products/components/product-form.tsx
+++ b/src/features/products/components/product-form.tsx
@@ -431,21 +431,31 @@ export const ProductForm = ({ product }: ProductFormProps) => {
             />
           </FormField>
 
-          <Button
-            type='submit'
-            disabled={
-              (!isDirty &&
-                newImageFiles.length === 0 &&
-                pendingImageOrder === null) ||
-              isPending
-            }
-          >
-            {isPending
-              ? 'Saving...'
-              : isEditing
-                ? 'Save changes'
-                : 'Create product'}
-          </Button>
+          <div className='flex justify-between'>
+            <Button
+              type='submit'
+              disabled={
+                (!isDirty &&
+                  newImageFiles.length === 0 &&
+                  pendingImageOrder === null) ||
+                isPending
+              }
+            >
+              {isPending
+                ? 'Saving...'
+                : isEditing
+                  ? 'Save changes'
+                  : 'Create product'}
+            </Button>
+            <Button
+              type='button'
+              variant='outline'
+              disabled={isPending}
+              onClick={() => navigate({ to: '/products' })}
+            >
+              Cancel
+            </Button>
+          </div>
         </form>
       </CardContent>
     </Card>

--- a/src/features/products/components/product-form.tsx
+++ b/src/features/products/components/product-form.tsx
@@ -19,7 +19,6 @@ import type {
   ProductImageDto,
 } from '@/api/generated/types.gen';
 import { FormField } from '@/components/shared/form-field';
-import { ImageUpload } from '@/components/shared/image-upload';
 import { SortableImageGrid } from './sortable-image-grid';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -399,47 +398,38 @@ export const ProductForm = ({ product }: ProductFormProps) => {
             </FormField>
           </div>
 
-          {isEditing && product ? (
-            <FormField label='Images' name='images'>
-              <SortableImageGrid
-                existingImages={
-                  pendingImageOrder
+          <FormField label='Images' name='images'>
+            <SortableImageGrid
+              existingImages={
+                isEditing && product
+                  ? pendingImageOrder
                     ? pendingImageOrder.reduce<ProductImageDto[]>((acc, id) => {
                         const img = product.images.find((img) => img.id === id);
                         if (img) acc.push(img);
                         return acc;
                       }, [])
                     : product.images
-                }
-                newFiles={newImageFiles}
-                onReorder={handleReorder}
-                onNewFilesReorder={setNewImageFiles}
-                onRemoveExisting={(imageId) =>
+                  : []
+              }
+              newFiles={newImageFiles}
+              onReorder={handleReorder}
+              onNewFilesReorder={setNewImageFiles}
+              onRemoveExisting={(imageId) => {
+                if (product) {
                   removeImageMutation.mutate({
                     path: { id: product.id, imageId },
-                  })
+                  });
                 }
-                onRemoveNew={(index) =>
-                  setNewImageFiles((prev) => prev.filter((_, i) => i !== index))
-                }
-                onAddFiles={(files) =>
-                  setNewImageFiles((prev) => [...prev, ...files])
-                }
-                disabled={isPending}
-              />
-            </FormField>
-          ) : (
-            <FormField label='Add Images' name='newImage'>
-              <ImageUpload
-                value={newImageFiles}
-                onChange={(files) =>
-                  setNewImageFiles(
-                    files.filter((f): f is File => f instanceof File),
-                  )
-                }
-              />
-            </FormField>
-          )}
+              }}
+              onRemoveNew={(index) =>
+                setNewImageFiles((prev) => prev.filter((_, i) => i !== index))
+              }
+              onAddFiles={(files) =>
+                setNewImageFiles((prev) => [...prev, ...files])
+              }
+              disabled={isPending}
+            />
+          </FormField>
 
           <Button
             type='submit'

--- a/src/features/products/components/sortable-image-grid.tsx
+++ b/src/features/products/components/sortable-image-grid.tsx
@@ -1,0 +1,272 @@
+import { useRef, useState } from 'react';
+import { DragDropProvider } from '@dnd-kit/react';
+import { useSortable, isSortable } from '@dnd-kit/react/sortable';
+import { GripVertical, Trash2, Upload, X } from 'lucide-react';
+
+import type { ProductImageDto } from '@/api/generated/types.gen';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+type ImageItem =
+  | { id: string; type: 'existing'; image: ProductImageDto }
+  | { id: string; type: 'new'; file: File };
+
+type SortableImageGridProps = {
+  existingImages: ProductImageDto[];
+  newFiles: File[];
+  onReorder: (imageIds: string[]) => void;
+  onNewFilesReorder: (files: File[]) => void;
+  onRemoveExisting: (imageId: string) => void;
+  onRemoveNew: (index: number) => void;
+  onAddFiles: (files: File[]) => void;
+  disabled?: boolean;
+};
+
+const DEFAULT_ACCEPT = 'image/jpeg,image/png,image/webp';
+const DEFAULT_MAX_SIZE_MB = 5;
+
+const previewCache = new WeakMap<File, string>();
+
+const getOrCreatePreview = (file: File): string => {
+  let url = previewCache.get(file);
+  if (!url) {
+    url = URL.createObjectURL(file);
+    previewCache.set(file, url);
+  }
+  return url;
+};
+
+const buildItems = (
+  existingImages: ProductImageDto[],
+  newFiles: File[],
+): ImageItem[] => {
+  const existing: ImageItem[] = existingImages.map((image) => ({
+    id: image.id,
+    type: 'existing',
+    image,
+  }));
+  const newItems: ImageItem[] = newFiles.map((file, i) => ({
+    id: `new-${i}`,
+    type: 'new',
+    file,
+  }));
+  return [...existing, ...newItems];
+};
+
+type SortableImageProps = {
+  item: ImageItem;
+  index: number;
+  isFirst: boolean;
+  disabled: boolean;
+  onRemove: () => void;
+};
+
+const SortableImage = ({
+  item,
+  index,
+  isFirst,
+  disabled,
+  onRemove,
+}: SortableImageProps) => {
+  const { ref } = useSortable({ id: item.id, index, disabled });
+
+  const src =
+    item.type === 'existing' ? item.image.url : getOrCreatePreview(item.file);
+
+  const alt =
+    item.type === 'existing'
+      ? typeof item.image.alt === 'string'
+        ? item.image.alt
+        : 'Product image'
+      : item.file.name;
+
+  return (
+    <div
+      ref={ref}
+      className='group relative h-20 w-20 cursor-grab rounded-md border active:cursor-grabbing sm:h-24 sm:w-24'
+    >
+      <img
+        src={src}
+        alt={alt}
+        className='h-full w-full rounded-md object-cover'
+      />
+
+      {isFirst && (
+        <Badge className='absolute bottom-1 left-1 text-[10px]'>Main</Badge>
+      )}
+
+      <div className='pointer-events-none absolute inset-0 flex items-center justify-center rounded-md bg-black/0 transition-colors group-hover:bg-black/10'>
+        <GripVertical className='text-white opacity-0 drop-shadow-md transition-opacity group-hover:opacity-100' />
+      </div>
+
+      {!disabled && (
+        <Button
+          type='button'
+          variant='destructive'
+          size='icon'
+          className='absolute -top-2 -right-2 size-6 opacity-0 transition-opacity group-hover:opacity-100'
+          aria-label={`Remove image ${index + 1}`}
+          onClick={onRemove}
+        >
+          {item.type === 'existing' ? (
+            <Trash2 className='size-3' />
+          ) : (
+            <X className='size-3' />
+          )}
+        </Button>
+      )}
+    </div>
+  );
+};
+
+const SortableImageGrid = ({
+  existingImages,
+  newFiles,
+  onReorder,
+  onNewFilesReorder,
+  onRemoveExisting,
+  onRemoveNew,
+  onAddFiles,
+  disabled = false,
+}: SortableImageGridProps) => {
+  const [isDragging, setIsDragging] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const items = buildItems(existingImages, newFiles);
+
+  const applyReorder = (initialIndex: number, index: number) => {
+    if (initialIndex === index) return;
+
+    const reordered = [...items];
+    const [removed] = reordered.splice(initialIndex, 1);
+    reordered.splice(index, 0, removed);
+
+    const reorderedExisting = reordered.filter(
+      (item): item is ImageItem & { type: 'existing' } =>
+        item.type === 'existing',
+    );
+    const reorderedNew = reordered.filter(
+      (item): item is ImageItem & { type: 'new' } => item.type === 'new',
+    );
+
+    onReorder(reorderedExisting.map((item) => item.image.id));
+    onNewFilesReorder(reorderedNew.map((item) => item.file));
+  };
+
+  const validateFile = (file: File): boolean => {
+    const allowedTypes = DEFAULT_ACCEPT.split(',').map((t) => t.trim());
+    if (!allowedTypes.includes(file.type)) {
+      setError(`File type must be one of: ${allowedTypes.join(', ')}`);
+      return false;
+    }
+    if (file.size > DEFAULT_MAX_SIZE_MB * 1024 * 1024) {
+      setError(`File size must be less than ${DEFAULT_MAX_SIZE_MB}MB`);
+      return false;
+    }
+    return true;
+  };
+
+  const addFiles = (fileList: FileList) => {
+    setError(null);
+    const toAdd: File[] = [];
+    for (let i = 0; i < fileList.length; i++) {
+      if (validateFile(fileList[i])) {
+        toAdd.push(fileList[i]);
+      } else {
+        return;
+      }
+    }
+    if (toAdd.length > 0) onAddFiles(toAdd);
+  };
+
+  const handleClick = () => {
+    if (disabled) return;
+    inputRef.current?.click();
+  };
+
+  const handleRemove = (item: ImageItem, index: number) => {
+    if (item.type === 'existing') {
+      onRemoveExisting(item.image.id);
+    } else {
+      const newIndex = index - existingImages.length;
+      onRemoveNew(newIndex);
+    }
+  };
+
+  return (
+    <div className='flex flex-col gap-2'>
+      <DragDropProvider
+        onDragEnd={(event) => {
+          if (event.canceled) return;
+          const source = event.operation.source;
+          if (!isSortable(source)) return;
+          applyReorder(source.initialIndex, source.index);
+        }}
+      >
+        <div className='flex flex-wrap gap-4'>
+          {items.map((item, index) => (
+            <SortableImage
+              key={item.id}
+              item={item}
+              index={index}
+              isFirst={index === 0}
+              disabled={disabled}
+              onRemove={() => handleRemove(item, index)}
+            />
+          ))}
+
+          <div
+            role='button'
+            tabIndex={0}
+            onClick={handleClick}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') handleClick();
+            }}
+            onDragOver={(e) => {
+              e.preventDefault();
+              if (!disabled) setIsDragging(true);
+            }}
+            onDragLeave={() => setIsDragging(false)}
+            onDrop={(e) => {
+              e.preventDefault();
+              setIsDragging(false);
+              if (!disabled && e.dataTransfer.files.length > 0) {
+                addFiles(e.dataTransfer.files);
+              }
+            }}
+            className={cn(
+              'flex h-20 w-20 flex-col items-center justify-center gap-1 rounded-md border-2 border-dashed transition-colors sm:h-24 sm:w-24',
+              isDragging
+                ? 'border-primary bg-primary/5'
+                : 'border-muted-foreground/25 hover:border-primary/50',
+              disabled && 'pointer-events-none opacity-50',
+            )}
+          >
+            <Upload className='text-muted-foreground size-5' />
+            <p className='text-muted-foreground text-[10px]'>Add</p>
+          </div>
+        </div>
+      </DragDropProvider>
+
+      <input
+        ref={inputRef}
+        type='file'
+        accept={DEFAULT_ACCEPT}
+        multiple
+        onChange={(e) => {
+          if (e.target.files && e.target.files.length > 0) {
+            addFiles(e.target.files);
+          }
+          e.target.value = '';
+        }}
+        className='hidden'
+      />
+
+      {error && <p className='text-destructive text-sm'>{error}</p>}
+    </div>
+  );
+};
+
+export { SortableImageGrid };

--- a/src/features/products/components/sortable-image-grid.tsx
+++ b/src/features/products/components/sortable-image-grid.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { DragDropProvider } from '@dnd-kit/react';
 import { useSortable, isSortable } from '@dnd-kit/react/sortable';
 import { GripVertical, Trash2, Upload, X } from 'lucide-react';
@@ -35,6 +35,14 @@ const getOrCreatePreview = (file: File): string => {
     previewCache.set(file, url);
   }
   return url;
+};
+
+const revokePreview = (file: File) => {
+  const url = previewCache.get(file);
+  if (url) {
+    URL.revokeObjectURL(url);
+    previewCache.delete(file);
+  }
 };
 
 let nextFileId = 0;
@@ -146,6 +154,19 @@ const SortableImageGrid = ({
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
+  const newFilesRef = useRef(newFiles);
+  useEffect(() => {
+    newFilesRef.current = newFiles;
+  }, [newFiles]);
+
+  useEffect(() => {
+    return () => {
+      for (const file of newFilesRef.current) {
+        revokePreview(file);
+      }
+    };
+  }, []);
+
   const items = buildItems(existingImages, newFiles);
 
   const applyReorder = (initialIndex: number, index: number) => {
@@ -202,6 +223,7 @@ const SortableImageGrid = ({
     if (item.type === 'existing') {
       onRemoveExisting(item.image.id);
     } else {
+      revokePreview(item.file);
       const newIndex = index - existingImages.length;
       onRemoveNew(newIndex);
     }

--- a/src/features/products/components/sortable-image-grid.tsx
+++ b/src/features/products/components/sortable-image-grid.tsx
@@ -89,7 +89,13 @@ const SortableImage = ({
   disabled,
   onRemove,
 }: SortableImageProps) => {
-  const { ref } = useSortable({ id: item.id, index, disabled });
+  const { ref } = useSortable({
+    id: item.id,
+    index,
+    disabled,
+    type: item.type,
+    accept: [item.type],
+  });
 
   const src =
     item.type === 'existing' ? item.image.url : getOrCreatePreview(item.file);
@@ -154,14 +160,20 @@ const SortableImageGrid = ({
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const newFilesRef = useRef(newFiles);
+  const prevFilesRef = useRef(newFiles);
+
   useEffect(() => {
-    newFilesRef.current = newFiles;
+    const prevFiles = prevFilesRef.current;
+    const removedFiles = prevFiles.filter((f) => !newFiles.includes(f));
+    for (const file of removedFiles) {
+      revokePreview(file);
+    }
+    prevFilesRef.current = newFiles;
   }, [newFiles]);
 
   useEffect(() => {
     return () => {
-      for (const file of newFilesRef.current) {
+      for (const file of prevFilesRef.current) {
         revokePreview(file);
       }
     };

--- a/src/features/products/components/sortable-image-grid.tsx
+++ b/src/features/products/components/sortable-image-grid.tsx
@@ -37,6 +37,18 @@ const getOrCreatePreview = (file: File): string => {
   return url;
 };
 
+let nextFileId = 0;
+const fileIdCache = new WeakMap<File, string>();
+
+const getFileId = (file: File): string => {
+  let id = fileIdCache.get(file);
+  if (!id) {
+    id = `new-${nextFileId++}`;
+    fileIdCache.set(file, id);
+  }
+  return id;
+};
+
 const buildItems = (
   existingImages: ProductImageDto[],
   newFiles: File[],
@@ -46,8 +58,8 @@ const buildItems = (
     type: 'existing',
     image,
   }));
-  const newItems: ImageItem[] = newFiles.map((file, i) => ({
-    id: `new-${i}`,
+  const newItems: ImageItem[] = newFiles.map((file) => ({
+    id: getFileId(file),
     type: 'new',
     file,
   }));

--- a/src/features/products/index.ts
+++ b/src/features/products/index.ts
@@ -1,2 +1,3 @@
 export { columns as productsColumns } from './components/products-columns';
 export { ProductForm } from './components/product-form';
+export { SortableImageGrid } from './components/sortable-image-grid';

--- a/src/features/shipping/components/shipping-form.tsx
+++ b/src/features/shipping/components/shipping-form.tsx
@@ -260,13 +260,23 @@ export const ShippingForm = ({ method }: ShippingFormProps) => {
             />
           </FormField>
 
-          <Button type='submit' disabled={!isDirty || isPending}>
-            {isPending
-              ? 'Saving...'
-              : isEditing
-                ? 'Save changes'
-                : 'Create shipping method'}
-          </Button>
+          <div className='flex justify-between'>
+            <Button type='submit' disabled={!isDirty || isPending}>
+              {isPending
+                ? 'Saving...'
+                : isEditing
+                  ? 'Save changes'
+                  : 'Create shipping method'}
+            </Button>
+            <Button
+              type='button'
+              variant='outline'
+              disabled={isPending}
+              onClick={() => navigate({ to: '/shipping' })}
+            >
+              Cancel
+            </Button>
+          </div>
         </form>
       </CardContent>
     </Card>

--- a/src/features/users/components/user-form.tsx
+++ b/src/features/users/components/user-form.tsx
@@ -150,9 +150,22 @@ export const UserForm = ({ user }: UserFormProps) => {
             />
           </FormField>
 
-          <Button type='submit' disabled={!isDirty || updateMutation.isPending}>
-            {updateMutation.isPending ? 'Saving...' : 'Save changes'}
-          </Button>
+          <div className='flex justify-between'>
+            <Button
+              type='submit'
+              disabled={!isDirty || updateMutation.isPending}
+            >
+              {updateMutation.isPending ? 'Saving...' : 'Save changes'}
+            </Button>
+            <Button
+              type='button'
+              variant='outline'
+              disabled={updateMutation.isPending}
+              onClick={() => navigate({ to: '/users' })}
+            >
+              Cancel
+            </Button>
+          </div>
         </form>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- **Fix #81**: Invalidate product and inventory list caches after stock adjustment in `adjust-stock-form.tsx`
- **Fix #79**: Add drag-to-reorder product images using `@dnd-kit/react` with "Main" badge, buffered reorder (persists only on Save), and unified `SortableImageGrid` component for both create and edit modes
- **Add cancel buttons** to all create/edit forms (products, categories, coupons, shipping, users, inventory) with `justify-between` layout

## Changes
- `adjust-stock-form.tsx` — add missing `productsControllerFindAll*` and `inventoryControllerGetProducts` cache invalidations + cancel button
- `sortable-image-grid.tsx` — new component: drag-to-reorder grid with stable file IDs, object URL cleanup, file validation, and upload tile
- `product-form.tsx` — integrate `SortableImageGrid`, buffer reorder in `pendingImageOrder` state, persist via `reorderImagesMutation` on submit
- `category-form.tsx`, `coupon-form.tsx`, `shipping-form.tsx`, `user-form.tsx` — add cancel buttons
- Updated OpenAPI spec and regenerated client with reorder endpoint
- Added `@dnd-kit/react` and `@dnd-kit/helpers` dependencies

Closes #81, closes #79